### PR TITLE
Update railties dependencies to >= 3.2.9

### DIFF
--- a/fontello-rails.gemspec
+++ b/fontello-rails.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "railties", "~> 3.2.9"
+  gem.add_runtime_dependency "railties", ">= 3.2.9"
   gem.add_runtime_dependency "sass-rails", ">= 3.2.5"
 end


### PR DESCRIPTION
Update railties dependencies to enable gem use with apps that depend on Railties 4.0.0
